### PR TITLE
Add jvmTarget JavaVersion.VERSION_17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Fixes `Unknown Kotlin JVM target: 21` error.

```
* What went wrong:
Execution failed for task ':managed_configurations:compileDebugKotlin'.
> Error while evaluating property 'compilerOptions.jvmTarget' of task ':managed_configurations:compileDebugKotlin'.
   > Failed to calculate the value of property 'jvmTarget'.
      > Unknown Kotlin JVM target: 21
```